### PR TITLE
Add Japanese docs and server example

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,11 @@
+# aisandbox
+
+Codex用のサンドボックスです。
+
+## 使い方
+
+HTTPSサーバーを起動するには、以下を実行します。
+
+```bash
+python server/simple_https_server.py
+```

--- a/server/simple_https_server.py
+++ b/server/simple_https_server.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+"""
+簡単なHTTPSサーバー。ローカルテスト用。
+このサーバーはカレントディレクトリからHTTPSでファイルを配信します。
+"""
+
+import http.server
+import ssl
+
+
+def run(server_class=http.server.HTTPServer,
+        handler_class=http.server.SimpleHTTPRequestHandler):
+    """Start the HTTPS server."""
+    server_address = ('', 4443)
+    httpd = server_class(server_address, handler_class)
+    # Create or specify a certificate "server.pem" for real use
+    httpd.socket = ssl.wrap_socket(
+        httpd.socket, certfile='server.pem', server_side=True)
+    httpd.serve_forever()
+
+
+if __name__ == '__main__':
+    run()


### PR DESCRIPTION
## Summary
- add Japanese README with basic usage instructions
- add a simple HTTPS server file with Japanese docstring

## Testing
- `python3 -m py_compile server/simple_https_server.py`

------
https://chatgpt.com/codex/tasks/task_b_68675cd108bc8321998010938f857060